### PR TITLE
New Method `underscore_without_question_mark` to get rid of question marks

### DIFF
--- a/lib/case_transform.rb
+++ b/lib/case_transform.rb
@@ -22,6 +22,10 @@ module CaseTransform
       @underscore_cache ||= {}
     end
 
+    def underscore_without_question_mark_cache
+      @underscore_without_question_mark ||= {}
+    end
+
     # Transforms values to UpperCamelCase or PascalCase.
     #
     # @example:
@@ -76,6 +80,20 @@ module CaseTransform
       when Hash then value.deep_transform_keys! { |key| underscore(key) }
       when Symbol then underscore(value.to_s).to_sym
       when String then underscore_cache[value] ||= value.underscore
+      else value
+      end
+    end
+
+    # Transforms values to underscore_case and removed question marks from boolean methods.
+    #
+    # @example:
+    #    "some-key?" => "some_key",
+    def underscore_without_question_mark(value)
+      case value
+      when Array then value.map { |item| underscore_without_question_mark(item) }
+      when Hash then value.deep_transform_keys! { |key| underscore_without_question_mark(key) }
+      when Symbol then underscore_without_question_mark(value.to_s).to_sym
+      when String then underscore_without_question_mark_cache[value] ||= value.underscore.sub(/\?\z/, '')
       else value
       end
     end

--- a/test/transforms/underscore_without_question_mark_test.rb
+++ b/test/transforms/underscore_without_question_mark_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe CaseTransform do
+  describe 'Transforms' do
+    describe 'underscore_without_question_mark' do
+      it 'transforms to underscore_without_question_mark (snake case)' do
+        obj = Object.new
+        scenarios = [
+          {
+            value: { :"some-key?" => 'value' },
+            expected: { some_key: 'value' }
+          },
+          {
+            value: { 'some-key?' => 'value' },
+            expected: { 'some_key' => 'value' }
+          },
+          {
+            value: { SomeKey?: 'value' },
+            expected: { some_key: 'value' }
+          },
+          {
+            value: { 'SomeKey?' => 'value' },
+            expected: { 'some_key' => 'value' }
+          },
+          {
+            value: { someKey?: 'value' },
+            expected: { some_key: 'value' }
+          },
+          {
+            value: { 'someKey?' => 'value' },
+            expected: { 'some_key' => 'value' }
+          },
+          {
+            value: :"some-value?",
+            expected: :some_value
+          },
+          {
+            value: :SomeValue?,
+            expected: :some_value
+          },
+          {
+            value: :someValue?,
+            expected: :some_value
+          },
+          {
+            value: 'some-value?',
+            expected: 'some_value'
+          },
+          {
+            value: 'SomeValue?',
+            expected: 'some_value'
+          },
+          {
+            value: 'someValue?',
+            expected: 'some_value'
+          },
+          {
+            value: obj,
+            expected: obj
+          },
+          {
+            value: nil,
+            expected: nil
+          },
+          {
+            value: [
+              { 'some-value?' => 'value' }
+            ],
+            expected: [
+              { 'some_value' => 'value' }
+            ]
+          }
+        ]
+        scenarios.each do |s|
+          result = CaseTransform.underscore_without_question_mark(s[:value])
+          assert_equal s[:expected], result
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
New Method `underscore_without_question_mark` to get rid of question marks in boolean methods.

I followed the discussion in the `active_model_serializers` project, but the solutions there are only valid for `<= 0.10.2`.
I guess there are more elegant ways to do this, but for this the code in `active_model_serializers` would need adjustment as well (e.g. pass an options hash to the `CamelCase.transform` method at https://github.com/rails-api/active_model_serializers/blob/v0.10.4/lib/active_model_serializers/adapter/base.rb#L34).